### PR TITLE
Bump httpclient in /aws-blog-hbase-on-emr/hbase-connector

### DIFF
--- a/aws-blog-hbase-on-emr/hbase-connector/pom.xml
+++ b/aws-blog-hbase-on-emr/hbase-connector/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.2 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:production ...