### PR TITLE
Bump hadoop-client in /aws-blog-hbase-on-emr/hbase-connector

### DIFF
--- a/aws-blog-hbase-on-emr/hbase-connector/pom.xml
+++ b/aws-blog-hbase-on-emr/hbase-connector/pom.xml
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
-			<version>2.4.0</version>
+			<version>2.7.0</version>
 		</dependency>	
 		<dependency>
     		<groupId>jdk.tools</groupId>


### PR DESCRIPTION
Bumps hadoop-client from 2.4.0 to 2.7.0.

---
updated-dependencies:
- dependency-name: org.apache.hadoop:hadoop-client dependency-type: direct:production ...