### PR TITLE
Bump commons-io in /aws-blog-mirth-healthcare-hub/mirth-aws-sample-app

### DIFF
--- a/aws-blog-mirth-healthcare-hub/mirth-aws-sample-app/pom.xml
+++ b/aws-blog-mirth-healthcare-hub/mirth-aws-sample-app/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
 <dependency>
     <groupId>org.json</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.4 to 2.7.

---
updated-dependencies:
- dependency-name: commons-io:commons-io dependency-type: direct:production ...